### PR TITLE
Do type checking for run statements

### DIFF
--- a/src/check.cpp
+++ b/src/check.cpp
@@ -424,25 +424,8 @@ start_check:
 
           Expr *code = read_code();
 
-          /* determine expected type of the result term, and make sure
-             the code term is an allowed one. */
-          Expr *progret = nullptr;
-          if (code->isArithTerm())
-          {
-            progret = statMpz;
-          }
-          else if (code->getop() == APP)
-          {
-            CExpr *call = (CExpr *)code;
-
-            // prog is not known to be a SymExpr yet
-            CExpr *prog = (CExpr *)call->get_head();
-
-            if (prog->getop() == PROG)
-            {
-              progret = prog->kids[0]->get_body();
-            }
-          }
+          // compute the type of the left hand side of the run statement
+          Expr *progret = check_code(code);
           if (progret==nullptr)
           {
             report_error(

--- a/src/check.cpp
+++ b/src/check.cpp
@@ -426,12 +426,6 @@ start_check:
 
           // compute the type of the left hand side of the run statement
           Expr *progret = check_code(code);
-          if (progret==nullptr)
-          {
-            report_error(
-                std::string("Could not determine how to run code ")
-                + code->toString());
-          }
           /* determine expected type of the result term, and make sure
                   the code term is an allowed one. */
 

--- a/src/code.cpp
+++ b/src/code.cpp
@@ -554,6 +554,8 @@ Expr *check_code(Expr *_e)
 
       Expr *tp1 = check_code(e->kids[1]);
       Expr *tp2 = check_code(e->kids[2]);
+      tp1 = tp1->followDefs();
+      tp2 = tp2->followDefs();
       if (tp1 != tp2)
       {
         report_error(
@@ -623,9 +625,12 @@ Expr *check_code(Expr *_e)
         report_error(errstr);
       }
 
-      SymSExpr *tp1 = (SymSExpr *)check_code(e->kids[2]);
-      SymSExpr *tp2 = (SymSExpr *)check_code(e->kids[3]);
-      if (tp1->getclass() != SYMS_EXPR || tp1->val || tp1 != tp2)
+      Expr *tp1 = check_code(e->kids[2]);
+      Expr *tp2 = check_code(e->kids[3]);
+      tp1 = tp1->followDefs();
+      tp2 = tp2->followDefs();
+      if (tp1 != tp2)
+      {
         report_error(
             string("\"ifmarked\" used with expressions that do not ")
             + string("have equal simple datatypes\nfor their types.\n")
@@ -634,6 +639,7 @@ Expr *check_code(Expr *_e)
             + string("\n2. second expression: ") + e->kids[3]->toString()
             + string("\n3. first expression's type: ") + tp1->toString()
             + string("\n4. second expression's type: ") + tp2->toString());
+      }
       return tp1;
     }
     case COMPARE:
@@ -661,9 +667,12 @@ Expr *check_code(Expr *_e)
         report_error(errstr1);
       }
 
-      SymSExpr *tp2 = (SymSExpr *)check_code(e->kids[2]);
-      SymSExpr *tp3 = (SymSExpr *)check_code(e->kids[3]);
-      if (tp2->getclass() != SYMS_EXPR || tp2->val || tp2 != tp3)
+      Expr *tp2 = check_code(e->kids[2]);
+      Expr *tp3 = check_code(e->kids[3]);
+      tp2 = tp2->followDefs();
+      tp3 = tp3->followDefs();
+      if (tp2 != tp3)
+      {
         report_error(
             string("\"compare\" used with expressions that do not ")
             + string("have equal simple datatypes\nfor their types.\n")
@@ -671,6 +680,7 @@ Expr *check_code(Expr *_e)
             + string("\n2. second expression: ") + e->kids[3]->toString()
             + string("\n3. first expression's type: ") + tp2->toString()
             + string("\n4. second expression's type: ") + tp3->toString());
+      }
       return tp2;
     }
     case IFEQUAL:
@@ -689,16 +699,20 @@ Expr *check_code(Expr *_e)
             + tp1->toString());
       }
 
-      SymSExpr *tpc1 = (SymSExpr *)check_code(e->kids[2]);
-      SymSExpr *tpc2 = (SymSExpr *)check_code(e->kids[3]);
-      if (tpc1->getclass() != SYMS_EXPR || tpc1->val || tpc1 != tpc2)
+      Expr *tpc1 = check_code(e->kids[2]);
+      Expr *tpc2 = check_code(e->kids[3]);
+      tpc1 = tpc1->followDefs();
+      tpc2 = tpc2->followDefs();
+      if (tpc1 != tpc2)
+      {
         report_error(
             string("\"ifequal\" used with return expressions that do not ")
-            + string("have equal simple datatypes\nfor their types.\n")
+            + string("have equal datatypes\nfor their types.\n")
             + string("\n1. first expression: ") + e->kids[2]->toString()
             + string("\n2. second expression: ") + e->kids[3]->toString()
             + string("\n3. first expression's type: ") + tpc1->toString()
             + string("\n4. second expression's type: ") + tpc2->toString());
+      }
       return tpc1;
     }
     case MATCH:

--- a/src/code.cpp
+++ b/src/code.cpp
@@ -554,15 +554,17 @@ Expr *check_code(Expr *_e)
 
       SymSExpr *tp1 = (SymSExpr *)check_code(e->kids[1]);
       SymSExpr *tp2 = (SymSExpr *)check_code(e->kids[2]);
-      if (tp1->getclass() != SYMS_EXPR || tp1->val || tp1 != tp2)
+      if (tp1 != tp2)
+      {
         report_error(
             string("\"mp_if\" used with expressions that do not ")
-            + string("have equal simple datatypes\nfor their types.\n")
+            + string("have equal datatypes\nfor their types.\n")
             + string("0. 0'th expression: ") + e->kids[0]->toString()
             + string("\n1. first expression: ") + e->kids[1]->toString()
             + string("\n2. second expression: ") + e->kids[2]->toString()
             + string("\n3. first expression's type: ") + tp1->toString()
             + string("\n4. second expression's type: ") + tp2->toString());
+      }
       return tp1;
     }
 

--- a/src/code.cpp
+++ b/src/code.cpp
@@ -633,7 +633,7 @@ Expr *check_code(Expr *_e)
       {
         report_error(
             string("\"ifmarked\" used with expressions that do not ")
-            + string("have equal simple datatypes\nfor their types.\n")
+            + string("have equal datatypes\nfor their types.\n")
             + string("0. 0'th expression: ") + e->kids[1]->toString()
             + string("\n1. first expression: ") + e->kids[2]->toString()
             + string("\n2. second expression: ") + e->kids[3]->toString()
@@ -685,8 +685,8 @@ Expr *check_code(Expr *_e)
     }
     case IFEQUAL:
     {
-      SymSExpr *tp0 = (SymSExpr *)check_code(e->kids[0]);
-      SymSExpr *tp1 = (SymSExpr *)check_code(e->kids[1]);
+      Expr *tp0 = check_code(e->kids[0]);
+      Expr *tp1 = check_code(e->kids[1]);
 
       if (tp0 != tp1)
       {

--- a/src/code.cpp
+++ b/src/code.cpp
@@ -552,8 +552,8 @@ Expr *check_code(Expr *_e)
             + string("1. the argument: ") + e->kids[0]->toString()
             + string("\n1. its type: ") + tp0->toString());
 
-      SymSExpr *tp1 = (SymSExpr *)check_code(e->kids[1]);
-      SymSExpr *tp2 = (SymSExpr *)check_code(e->kids[2]);
+      Expr *tp1 = check_code(e->kids[1]);
+      Expr *tp2 = check_code(e->kids[2]);
       if (tp1 != tp2)
       {
         report_error(

--- a/src/expr.h
+++ b/src/expr.h
@@ -160,20 +160,6 @@ class Expr
   {
     return getclass() == SYMS_EXPR || getop() == MPZ || getop() == MPQ;
   }
-  inline bool isArithTerm() const { return getop() == ADD || getop() == NEG; }
-  /*
-   *   inline bool isArithTerm() const { 
-    int op = getop();
-    return op == ADD || op == MUL || op == DIV || op == NEG || op == MPZ_TO_MPQ;
-  ADD,
-  MUL,
-  DIV,
-  NEG,
-  IFNEG,
-  IFZERO,
-  MPZ_TO_MPQ,
-  }
-  */
   inline bool isSymbolic() const
   {
     return getclass() == SYM_EXPR || getclass() == SYMS_EXPR;

--- a/src/expr.h
+++ b/src/expr.h
@@ -161,6 +161,19 @@ class Expr
     return getclass() == SYMS_EXPR || getop() == MPZ || getop() == MPQ;
   }
   inline bool isArithTerm() const { return getop() == ADD || getop() == NEG; }
+  /*
+   *   inline bool isArithTerm() const { 
+    int op = getop();
+    return op == ADD || op == MUL || op == DIV || op == NEG || op == MPZ_TO_MPQ;
+  ADD,
+  MUL,
+  DIV,
+  NEG,
+  IFNEG,
+  IFZERO,
+  MPZ_TO_MPQ,
+  }
+  */
   inline bool isSymbolic() const
   {
     return getclass() == SYM_EXPR || getclass() == SYMS_EXPR;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,6 +4,8 @@ set(lfsc_test_file_list
   bool.plf
   eq_mpz.plf
   issue20.plf
+  issue59.plf
+  issue60.plf
   issue8-mpexp.plf
   formal_type_args.plf
   mp_prefix.plf

--- a/tests/tests/issue59.plf
+++ b/tests/tests/issue59.plf
@@ -1,0 +1,1 @@
+(declare T (! sc (^ (mp_ifneg 10 0 1) 1) type))

--- a/tests/tests/issue60.plf
+++ b/tests/tests/issue60.plf
@@ -1,0 +1,1 @@
+(declare T (! sc (^ (mp_add 1/2 1/4) 3/4) type))

--- a/tests/tests/th_bv_bitblast.plf
+++ b/tests/tests/th_bv_bitblast.plf
@@ -160,7 +160,7 @@
 		       	(! xb bblt
 		       	(! rb bblt
 		       	(! xbb (bblast_term m x xb)
-			(! c ( ^ (bblast_zextend xb k m) rb)
+			(! c ( ^ (bblast_zextend xb k) rb)
                            (bblast_term n (zero_extend n k m x) rb))))))))))
 
 (program bblast_sextend ((x bblt) (i mpz)) bblt


### PR DESCRIPTION
We were not properly type checking the left hand side of run statements.  This fixes the issue.

Also makes our type checking for code terms allow for non-simple datatypes.

Fixes https://github.com/cvc5/LFSC/issues/59.
Fixes https://github.com/cvc5/LFSC/issues/60.