### PR TITLE
Add failing test from previous PR

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,6 +3,7 @@ set(lfsc_test_file_list
   bad-char.plf
   bool.plf
   eq_mpz.plf
+  error-pr15.plf
   issue20.plf
   issue59.plf
   issue60.plf

--- a/tests/tests/error-pr15.plf
+++ b/tests/tests/error-pr15.plf
@@ -1,0 +1,9 @@
+; errorline: 8
+
+(declare bool type)
+(declare tt bool)
+(declare ff bool)
+
+(program f1 ((n mpz)) mpz
+  (mp_ifneg n tt ff)
+)  


### PR DESCRIPTION
Adds test that could not be added on https://github.com/cvc5/LFSC/pull/15.