### PR TITLE
Support older versions of CMake

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, ubuntu-18.04]
         name: [ production ]
 
     name: ${{ matrix.os }}:${{ matrix.name }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8.9)
+cmake_minimum_required (VERSION 3.9)
 
 macro(add_cxx_flag flag)
   message(STATUS "Configure with flag '${flag}'")
@@ -32,7 +32,7 @@ else()
 endif()
 
 # For macOS, homebrew
-list(PREPEND CMAKE_PREFIX_PATH "/usr/local/opt/flex")
+list(APPEND CMAKE_PREFIX_PATH "/usr/local/opt/flex")
 find_package(FLEX REQUIRED)
 if (FLEX_FOUND AND NOT ${FLEX_INCLUDE_DIRS} STREQUAL "FLEX_INCLUDE_DIR-NOTFOUND")
     message(STATUS "Flex include directories: ${FLEX_INCLUDE_DIRS}")


### PR DESCRIPTION
`PREPEND` for lists was only introduced in CMake 3.15, but we require
cvc5 to build with CMake 3.9. This commit replaces the `PREPEND` by an
`APPEND`, adds an older version of Ubuntu as a CI test to catch these
issues in the future, and raises the minimum CMake version to 3.9 to
match cvc5's version requirements.

This change is similar to what we did in cvc5:
https://github.com/cvc5/cvc5/pull/7003